### PR TITLE
Only show 'Hi' on navbar when user is logged in

### DIFF
--- a/views/partials/navbars/search-header-index.hbs
+++ b/views/partials/navbars/search-header-index.hbs
@@ -11,9 +11,9 @@
                 <div class="col-12 col-md-12">
                     <div class="pro-header-options">
                         <div class="dropdown">
-
-                            <a class="pro-avatar">Hi&nbsp;{{ currentUserObject.firstname }}!</a>
-
+                            {{#if (user_is_logged_in currentUser)}}
+                                <a class="pro-avatar">Hi&nbsp;{{ currentUserObject.firstname }}!</a>
+                            {{/if}}
                         </div>
                         <div class="dropdown">
                             <a href="javascript:void(0);" class="dropdown-toggle">


### PR DESCRIPTION
### Fix for issue #52 
- Removed 'Hi' on navbar when user isn't logged in

### If user is logged in
<img width="1124" alt="Screen Shot 2020-10-07 at 8 42 19 PM" src="https://user-images.githubusercontent.com/39229239/95412626-4054e700-08de-11eb-978e-6233a1c09858.png">

### If user is not logged in
<img width="1126" alt="Screen Shot 2020-10-07 at 8 42 32 PM" src="https://user-images.githubusercontent.com/39229239/95412631-40ed7d80-08de-11eb-8c9b-525e35fa4ede.png">