### PR TITLE
Null searches/ all results will no longer show 'BookStack |' as the title of the tab, it will only show 'BookStack'

### DIFF
--- a/views/layouts/layout.hbs
+++ b/views/layouts/layout.hbs
@@ -7,6 +7,8 @@
 
         {{#if (equal_strings 'Home' title)}}
             <title> BookStack </title>
+        {{else if (equal_strings '' title)}}
+            <title> BookStack </title>
         {{else}}
             <title> BookStack | {{ title }}</title>
         {{/if}}


### PR DESCRIPTION
Beforehand, when we searched for all results, i.e. searched for '', it would say 'BookStack | ' as the title, but we have changed it to just say 'BookStack' in the title if no search term was specified

close #81 