### PR TITLE
Added email verifications for #80

### DIFF
--- a/routes/profile_routes.js
+++ b/routes/profile_routes.js
@@ -413,7 +413,11 @@ router.route('/profile/settings')
             { lastname } = request.body,
             { email } = request.body;
 
-
+        if(!(email.endsWith("@ucla.edu") || email.endsWith("@g.ucla.edu"))){
+            let err = new Error("Please use your UCLA email (:")
+            return next(err);
+        }
+        
         User.findOne({_id: request.session.userId})
             .then(user=> {
                 user.firstname = firstname;


### PR DESCRIPTION
Added email verification for #80 in profile_routes.js

Simple add of an if-then statement so we don't get users registering with bogus UCLA emails only to have Gmail accounts added in later

Closes #80 