### PR TITLE
Fixed issues #40 and #62

### DIFF
--- a/views/layouts/layout.hbs
+++ b/views/layouts/layout.hbs
@@ -24,7 +24,6 @@
         {{! Here we link bootstrap css again to apply to the collapsable menu in search_for_books,
         the only place it causes interferences with styles is index.css, the 'we use cookies' banner }}
         {{! It actually also doesnt allow the sticky dropdown menu to dropdown. This is an issue needing fixing. But we need this in order to use collapsable menu }}
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.js" integrity="sha512-v8ng/uGxkge3d1IJuEo6dJP8JViyvms0cly9pnbfRxT6/31c3dRWxIiwGnMSWwZjHKOuY3EVmijs7k1jz/9bLA==" crossorigin="anonymous"></script>
     </head>
 


### PR DESCRIPTION
Fixed issues #40 and #62 

Problem: Default bootstrap css included multiple times

Solution:
On line 26 of layout.hbs the default bootstrap files were included a second time. This second include was at the base of other included css files resulting in a higher style priority.

Changed Files:
layout.hbs

close #40 
close #62

Signed-off-by: noahtarr <nrtarr@ucdavis.edu>